### PR TITLE
h264: Update the H264 control headers

### DIFF
--- a/src/header_h264.c
+++ b/src/header_h264.c
@@ -196,7 +196,7 @@ static void h264_dump_dpb(struct dump_driver_data *driver_data,
 		print_indent(indent++, "[%d] = {\n", i);
 
 		print_indent(indent, ".frame_num = %d,\n", pic->frame_idx);
-		print_indent(indent, ".timestamp = TS_REF_INDEX(%d),\n", entry->tag);
+		print_indent(indent, ".reference_ts = TS_REF_INDEX(%d),\n", entry->tag);
 		print_indent(indent, ".top_field_order_cnt = %d,\n",
 			     pic->TopFieldOrderCnt);
 		print_indent(indent, ".bottom_field_order_cnt = %d,\n",
@@ -218,7 +218,7 @@ static void h264_emit_picture_parameter(struct dump_driver_data *driver_data,
 	VAPictureParameterBufferH264 *picture_params =
 		&driver_data->params.h264.picture;
 
-	print_indent(indent++, ".decode_param = {\n");
+	print_indent(indent++, ".decode_params = {\n");
 	print_indent(indent, ".top_field_order_cnt = %d,\n",
 		     picture_params->CurrPic.TopFieldOrderCnt);
 	print_indent(indent, ".bottom_field_order_cnt = %d,\n",
@@ -314,7 +314,7 @@ static void h264_emit_slice_parameter(struct dump_driver_data *driver_data,
 		&driver_data->params.h264.slice;
 	int i;
 
-	print_indent(indent++, ".slice_param = {\n");
+	print_indent(indent++, ".slice_params = {\n");
 	print_indent(indent, ".size = %u,\n", slice_params->slice_data_size);
 	print_indent(indent, ".header_bit_size = %u,\n", slice_params->slice_data_bit_offset);
 	print_indent(indent, ".first_mb_in_slice = %u,\n", slice_params->first_mb_in_slice);


### PR DESCRIPTION
The H264 controls that got merged into the kernel have a few fields that
had changed their name slightly. Update libva-dump to reflect this.

Signed-off-by: Maxime Ripard <maxime@cerno.tech>